### PR TITLE
Update jiffy to 0.11.3

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -6,5 +6,5 @@
 	{platform_define, "^R14", no_callbacks}
 ]}.
 {deps, [
-	{jiffy, ".*", {git, "http://github.com/davisp/jiffy.git", {tag, "0.8.2"}}}
+	{jiffy, ".*", {git, "http://github.com/davisp/jiffy.git", {tag, "0.11.3"}}}
 ]}.


### PR DESCRIPTION
0.8.2 emits compile error on gcc 4.8/4.9 because of
-Wall -Werror options, so update it to latest tag.
