### PR TITLE
Make http request async

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,22 @@ or just the DSN:
 
 Now all events logged using error_logger will be sent to the [Sentry](http://aboutsentry.com/) service.
 
+
+All error logging is done synchronously. If you want to log errors in async, you can set flag on config.
+
+```erlang
+{raven, [
+    {dsn, "https://PUBLIC_KEY:PRIVATE_KEY@app.getsentry.com/1"},
+    {error_logger, true},
+    {async, true}
+]}.
+```
+
+If you want to send some errors in async, use ```raven:capture/3```
+```erlang
+raven:capture("Test Event", [{foo, bar}], [async]).
+```
+
 Advanced Usage
 ==============
 


### PR DESCRIPTION
raven:capture/2 blocks until http request finishes. It can slow
down error_logger when raven is used with {error_logger, true}
because error_logger waits until raven_capture/2 finishes.

Currently raven:capture/2 does not check return value of http
request so it's safe to make http request async.
