### PR TITLE
Make the Process Crashed error reporting optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ It will accept either the individual config components:
     {private_key, "PRIVATE_KEY"},
     {error_logger, true},  % Set to true in order to install the standard error logger
     {ipfamily, inet}  % Set to inet6 to use IPv6. See `ipfamily` in `httpc:set_options/1` for more information.
+    {ignore_process_crashed, true}  % Set to true to not report `Processed Crashed` errors to sentry.
 ]}.
 ```
 

--- a/src/raven.app.src
+++ b/src/raven.app.src
@@ -18,6 +18,7 @@
 		{public_key, ""},
 		{private_key, ""},
 		{error_logger, false},
-		{ipfamily, inet}
+		{ipfamily, inet},
+		{ignore_process_crashed, false}
 	]}
 ]}.


### PR DESCRIPTION
Apologies for the brute force approach, but it works for me and figured I'd offer it up in case you wanted it.

I found the process crashed error a bit noisy when combined with the accompanying supervisor error about the child exiting so I made the Process Crashed error optional.

Default behavior is to continue to submit the reports.
