### PR TITLE
don't try to generate frames for empty stacktrace

### DIFF
--- a/src/raven.erl
+++ b/src/raven.erl
@@ -36,6 +36,8 @@ capture(Message, Params) ->
 		{timestamp, timestamp_i()},
 		{message, term_to_json_i(Message)} |
 		lists:map(fun
+			({stacktrace, []}) ->
+				{'sentry.interfaces.Stacktrace', {[]}};
 			({stacktrace, Value}) ->
 				{'sentry.interfaces.Stacktrace', {[
 					{frames,lists:reverse([frame_to_json_i(Frame) || Frame <- Value])}


### PR DESCRIPTION
The last example from README tries to submit event to Sentry with empty stack trace and it triggers error at Sentry server side:

```
Discarded invalid value for interface: sentry.interfaces.Stacktrace
Traceback (most recent call last):
  File "/home/mayoi/tmp/sentry/src/sentry/coreapi.py", line 356, in validate_data
    inst = interface.to_python(value)
  File "/home/mayoi/tmp/sentry/src/sentry/interfaces/stacktrace.py", line 451, in to_python
    assert data.get('frames')
AssertionError
```

It doesn't influence Sentry functionality but just looks disgusting.

After this patch the only message appears in Sentry log in such cases:

```
Ignored empty interface value: sentry.interfaces.Stacktrace
```
